### PR TITLE
Shift '--target' argument to the right of the 'test' command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test --target ${{ inputs.target }} ${{ inputs.args }} 
+        ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test --target ${{ inputs.target }} ${{ inputs.args }}
       if: ${{ inputs.command != 'build' && runner.os != 'Windows' }}
     # We want to run in Powershell on Windows to make sure we compile in a
     # native Windows environment. Some things won't compile properly under

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test ${{ inputs.args }} --target ${{ inputs.target }}
+        ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test --target ${{ inputs.target }} ${{ inputs.args }} 
       if: ${{ inputs.command != 'build' && runner.os != 'Windows' }}
     # We want to run in Powershell on Windows to make sure we compile in a
     # native Windows environment. Some things won't compile properly under
@@ -96,7 +96,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: powershell
       run: |
-        & ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test ${{ inputs.args }} --target ${{ inputs.target }}
+        & ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test --target ${{ inputs.target }} ${{ inputs.args }}
       if: ${{ inputs.command != 'build' && runner.os == 'Windows' }}
     - name: Build binary (*nix)
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
I have a library that requires tests to run sequentially. When using this action, I'd add `-- --test-threads=1` to the `args` section. Sadly, this didn't work. After some digging, I noticed the `--target` argument is appended to the user args. Instead, I have prepended the `--target` argument.