### PR TITLE
Bump actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
       if: ${{ steps.determine-cross-compile.outputs.needs-cross == 'true' }}
     - name: Cache cross
       id: cache-cross
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.set-cross-dir.outputs.cross-dir }}/cross
         key: ${{ runner.os }}-${{ steps.determine-cross-version.outputs.cross-version }}


### PR DESCRIPTION
v3 is based on Node 16 which be deprecated in action runner, so I switch to `actions/checkout@v4`.

You can see [here (my job)](https://github.com/hms5232/get-LAN-IP-telegram-bot-rs/actions/runs/8036986835) or the following text for detail:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
