### PR TITLE
Put test 'args' at the end of the test command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,6 +243,16 @@ jobs:
           target: ${{ matrix.platform.target }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ matrix.platform.can_test }}
+      - name: Run test command with args
+        uses: ./
+        with:
+          command: test
+          cross-version: ${{ matrix.platform.cross-version }}
+          cache-cross-binary: ${{ matrix.platform.cache-cross-binary }}
+          target: ${{ matrix.platform.target }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: "-- --ignored"
+        if: ${{ matrix.platform.can_test }}
       - name: Run build command
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
-        ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test ${{ inputs.args }} --target ${{ inputs.target }}
+        ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test --target ${{ inputs.target }} ${{ inputs.args }}
       if: inputs.command != 'build' && runner.os != 'Windows'
     # We want to run in Powershell on Windows to make sure we compile in a
     # native Windows environment. Some things won't compile properly under
@@ -105,7 +105,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: powershell
       run: |
-        & ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test ${{ inputs.args }} --target ${{ inputs.target }}
+        & ${{ steps.set-build-command.outputs.build-command }} +${{inputs.toolchain}} test --target ${{ inputs.target }} ${{ inputs.args }}
       if: inputs.command != 'build' && runner.os == 'Windows'
     - name: Build binary (*nix)
       working-directory: ${{ inputs.working-directory }}

--- a/test-project/src/bin2.rs
+++ b/test-project/src/bin2.rs
@@ -8,4 +8,10 @@ mod test {
     fn test_something() {
         assert_eq!(1, 1);
     }
+
+    #[test]
+    #[ignore]
+    fn test_something_ignored() {
+        assert_eq!(2, 2);
+    }
 }


### PR DESCRIPTION
For test command, there can be arguments passed to the test binary like `-- --ignored` or `-- --test-threads=1`. For these cases to work properly, the `args` parameter needs to be added to the end of the 'test' command.