### PR TITLE
docs(readme): fix pipeline error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v1
         with:
-          command: ${{ matrix.platform.command }}
+          command: build
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true


### PR DESCRIPTION
While trying out the action I copy pasted the example from the readme just to run into an error:
> Invalid 'command'. Must be one of ['bench', 'both', 'build', 'test']

So I replaced the missing variable with a simple build. 
Feel free to merge or close, just wanted to make the next developers life easier.
