### PR TITLE
Fix caching when the effective cache key would contain spaces

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,8 @@
-## 0.0.8
+## 1.0.7
 
 - Fixed a bug in calculating the `cross` binary's hash.
+- Fixed cache key handling to deal with spaces in cache key elements, for example in the OS version.
+  Reported by @gdubicki (Greg Dubicki). GH #50. Fixes #1.
 
 ## 1.0.6 2026-03-15
 

--- a/parse-and-set-rust-cache-parameters.py
+++ b/parse-and-set-rust-cache-parameters.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import hashlib
+import re
 
 
 def main():
@@ -32,6 +33,8 @@ def main():
             get_file_hash(build_command)
         )
 
+    parameters["key"] = sanitize_key(parameters["key"])
+
     file = os.environ["GITHUB_OUTPUT"]
     with open(file, "w") as f:
         for key, value in parameters.items():
@@ -44,6 +47,11 @@ def get_file_hash(build_command):
         while chunk := f.read(65536):
             file_hash.update(chunk)
         return file_hash.hexdigest()
+
+
+def sanitize_key(key):
+    # cache key cannot contain any whitespace
+    return re.sub(r"\s+", "-", key)
 
 
 main()


### PR DESCRIPTION
like when the OS name is something like "Ubuntu 24.04.4 LTS" for example.
Also, to be safer, replace all other whitespace with dashes too.

Resolves https://github.com/houseabsolute/actions-rust-cross/issues/51